### PR TITLE
Clean up Next.js example

### DIFF
--- a/src/pages/libraries/react-apollo.mdx
+++ b/src/pages/libraries/react-apollo.mdx
@@ -93,7 +93,6 @@ export { auth, storage };
 #### Usage
 
 ```jsx
-import React from "react";
 import { useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 


### PR DESCRIPTION
don't need to `import React from "react"` in Next.js