### PR TITLE
Switched "read" and "write" definitions

### DIFF
--- a/src/pages/storage/security-rules.mdx
+++ b/src/pages/storage/security-rules.mdx
@@ -149,8 +149,8 @@ The following operations can be used:
 
 You can also use helper operations:
 
-- `read` is the same as `create` and `update` and `delete`.
-- `write` is the same as `get` and `list`.
+- `write` is the same as `create` and `update` and `delete`.
+- `read` is the same as `get` and `list`.
 
 ## Access Token
 


### PR DESCRIPTION
- `read` is the same as `create` and `update` and `delete`.
- `write` is the same as `get` and `list`.
this didn't make sense, so I assumed it was a typo and flipped the definitions: 
- `write` is the same as `create` and `update` and `delete`.
- `read` is the same as `get` and `list`.