### PR TITLE
Update custom API docs with nhost init prereq

### DIFF
--- a/src/pages/custom-api/index.mdx
+++ b/src/pages/custom-api/index.mdx
@@ -6,8 +6,9 @@ Deploy a custom API on Nhost. Also called: Lambda, Serverless Functions, Cloud F
 
 To deploy the custom API you must:
 
-1. Connect your repository to your Nhost project under Settings -> Git.
-2. Have an `api/` directory at the root of your project.
+1. Init your project with the [nhost-cli](https://docs.nhost.io/cli): `nhost init`
+2. Connect your repository to your Nhost project under Settings -> Git.
+3. Have an `api/` directory at the root of your project.
 
 Your API will be automatically deployed for every push to the `master` or the `main` branch of your repository.
 


### PR DESCRIPTION
For new users, the getting started does not require `nhost init` to be run so it is confusing if you try to create a custom API for the first time why it doesn't work. Adding this prerequisite step should mitigate the confusion.