### PR TITLE
Remove graphql-tag dependency from docs

### DIFF
--- a/src/pages/graphql/variables.mdx
+++ b/src/pages/graphql/variables.mdx
@@ -17,8 +17,7 @@ mutation($todo: todos_insert_input!) {
 Here is an example using variables with the popular Apollo client.
 
 ```js
-import { useMutation } from "@apollo/client";
-import gql from "graphql-tag";
+import { gql, useMutation } from "@apollo/client";
 
 const INSERT_TODO = gql`
   mutation($todo: todos_insert_input!) {

--- a/src/pages/quick-start/authentication.mdx
+++ b/src/pages/quick-start/authentication.mdx
@@ -172,8 +172,7 @@ Finally, add two links to `App.js`. One to `/login` and one that will logout the
 
 ```jsx{4,5,22,23}:src/App.js
 import React, { useState } from "react";
-import { useSubscription, useMutation } from "@apollo/client";
-import gql from "graphql-tag";
+import { gql, useSubscription, useMutation } from "@apollo/client";
 import { Link } from "react-router-dom";
 import { auth } from "utils/nhost";
 

--- a/src/pages/quick-start/frontend-web-app.mdx
+++ b/src/pages/quick-start/frontend-web-app.mdx
@@ -18,7 +18,7 @@ Once completed, change the directory to the new project and install these packag
 
 ```bash
 $ cd nhost-todos
-$ npm install @nhost/react-apollo @apollo/client graphql graphql-tag react-router-dom
+$ npm install @nhost/react-apollo @apollo/client graphql react-router-dom
 ```
 
 Create a `jsconfig.json` file in the root of your project to make [imports easier](https://create-react-app.dev/docs/importing-a-component/#absolute-imports).
@@ -70,8 +70,7 @@ Replace all content of `src/App.js` with the following code:
 
 ```jsx:src/App.js
 import React from "react";
-import { useQuery } from "@apollo/client";
-import gql from "graphql-tag";
+import { gql, useQuery } from "@apollo/client";
 
 const GET_TODOS = gql`
   query {
@@ -119,8 +118,7 @@ We need to create a GraphQL mutation and add a simple form for inserting todos.
 
 ```jsx{1,2,7,11,12,20-44}:src/App.js
 import React, { useState } from "react";
-import { useQuery, useMutation } from "@apollo/client";
-import gql from "graphql-tag";
+import { gql, useQuery, useMutation } from "@apollo/client";
 
 const GET_TODOS = gql`
   query {
@@ -208,8 +206,7 @@ We'll replace `useQuery` with `useSubscription` and `query` with `subscription` 
 
 ```jsx{2,5,10}:src/App.js
 import React, { useState } from "react";
-import { useSubscription, useMutation } from "@apollo/client";
-import gql from "graphql-tag";
+import { gql, useSubscription, useMutation } from "@apollo/client";
 
 const GET_TODOS = gql`
   subscription {


### PR DESCRIPTION
Apollo Client v3 comes with an export of graphql-tag.

> The `@apollo/client` package includes `graphql-tag` as a dependency and re-exports `gql`. To simplify your dependencies, we recommend importing `gql` from `@apollo/client` and removing all `graphql-tag` dependencies.

https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#graphql-tag

I've refactored all occurrences in the docs to use the `gql` tag of `@apollo/client` except in the recommended list on the [@nhost/nuxt page](https://github.com/nhost/docs/blob/7913b8dabd96d0d9691e13df16645e6a9d280327/src/pages/libraries/nhost-nuxt.mdx), where I'm unsure if it's still useful, as I'm not well-versed in Vue-land. I quote:
> Other recommended NPM packages: `nhost-js-sdk @nuxtjs/apollo graphql-tag`

All occurrences can be found here:
https://github.com/nhost/docs/search?q=graphql-tag

Hope this is useful, and thank you so much for this wonderful platform!